### PR TITLE
[feature] ElevenLabs 음성 합성 구현

### DIFF
--- a/everTale/app/api.py
+++ b/everTale/app/api.py
@@ -1,10 +1,12 @@
 
-from fastapi import APIRouter
+import os, shutil, uuid
+
+from fastapi import APIRouter, HTTPException
 from fastapi import File, UploadFile, Form
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from . import dto
-from .service import image_service, quiz_service, story_service
+from .service import image_service, quiz_service, story_service, voice_cloning_service
 
 router = APIRouter(prefix="/ai")
 
@@ -83,3 +85,43 @@ def create_quiz(request: dto.QuizRequest):
         return quiz
     except ValueError as e:
         return JSONResponse(status_code=500, content={"error": str(e)})
+    
+@router.post("/voice/register")
+async def upload_voice(
+    file: UploadFile = File(...),
+    voice_name: str = Form(...)
+):
+    try:
+        temp_filename = f"temp_{uuid.uuid4().hex}_{file.filename}"
+        temp_path = os.path.join("/tmp", temp_filename)
+
+        with open(temp_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        voice_id = voice_cloning_service.record_voice(temp_path, voice_name)
+
+        os.remove(temp_path)
+
+        if voice_id:
+            return JSONResponse(content={"voice_id": voice_id})
+        else:
+            return JSONResponse(status_code=500, content={"error": "Voice cloning failed."})
+
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+@router.post("/voice/play", summary="음성 합성 API", description="voice_key와 텍스트를 받아 음성 스트림을 반환합니다.")
+def play_voice(request: dto.TTSRequest):
+    try:
+        audio_stream = voice_cloning_service.synthesize_voice(
+            request.voice_key,
+            request.text
+        )
+        return StreamingResponse(audio_stream, media_type="audio/mpeg")
+    
+    except ValueError as e:
+        print("[play_voice] ValueError 발생:", str(e))
+        raise HTTPException(status_code=500, detail=str(e))
+    
+    except Exception as e:
+        print("[play_voice] 예기치 못한 오류:", repr(e))
+        raise HTTPException(status_code=500, detail="서버 내부 오류 발생")

--- a/everTale/app/dto.py
+++ b/everTale/app/dto.py
@@ -74,3 +74,15 @@ class ControlNetImageRequest(BaseModel):
                 "genre": "모험"
             }
         }
+
+class TTSRequest(BaseModel):
+    voice_key: str = Field(
+        ...,
+        description="ElevenLabs에서 발급받은 voice_key (예: '9c74576ba45e6852f1c7d03')",
+        json_schema_extra={"example": "9c74576ba45e6852f1c7d03"}
+    )
+    text: str = Field(
+        ...,
+        description="복제된 음성으로 재생할 텍스트",
+        json_schema_extra={"example": "안녕, 오늘은 어떤 이야기를 들려줄까?"}
+    )

--- a/everTale/app/service/voice_cloning_service.py
+++ b/everTale/app/service/voice_cloning_service.py
@@ -1,0 +1,87 @@
+import os 
+import random 
+import requests
+
+from io import BytesIO
+from typing import Optional
+
+ELEVEN_API_KEY = os.environ["ELEVEN_API_KEY"]
+
+def record_voice(audio_file_path: str, voice_name: str) -> Optional[str]:
+    """
+    프론트에서 업로드된 녹음 파일과 사용자 지정 음성 이름을 받아 ElevenLabs로 전송하고 voice_id를 반환합니다.
+    :param audio_file_path: 로컬에 저장된 녹음 파일 경로
+    :return: 생성된 voice_id 또는 None
+    """
+    try:
+        voice_id = clone_voice(audio_file_path, voice_name)
+        if voice_id:
+            return voice_id
+        else:
+            print("voice_id 생성 실패")
+            return None
+    except Exception as e:
+        print("오류 발생:", str(e))
+        return None
+
+
+def clone_voice(audio_path: str, voice_name: str) -> Optional[str]:
+    """
+    ElevenLabs의 voice cloning API에 요청을 보내 사용자 음성을 등록합니다.
+    :param audio_path: 로컬에 저장된 음성 파일 경로
+    :voice_name: 음성 파일 이름
+    :return: 생성된 voice_id 또는 None
+    """
+    url = "https://api.elevenlabs.io/v1/voices/add"
+
+    headers = {
+        "xi-api-key": ELEVEN_API_KEY
+    }
+
+    files = {
+        "files": open(audio_path, "rb")
+    }
+
+    data = {
+        "name": voice_name,
+        "description": "사용자가 정의한 커스텀 음성입니다.",
+        "labels": "{}"
+    }
+
+    response = requests.post(url, headers=headers, data=data, files=files)
+
+    if response.status_code == 200:
+        return response.json().get("voice_id")
+    else:
+        print(response.text)
+        return None
+
+def synthesize_voice(voice_id: str, text: str) -> BytesIO:
+    """
+    주어진 voice_id와 텍스트를 기반으로 ElevenLabs API에 요청하여 음성 데이터를 반환합니다.
+    :param voice_id: 등록된 voice_id
+    :param text: 음성으로 변환할 텍스트
+    :return: 음성 데이터를 담은 BytesIO 스트림
+    """
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+
+    headers = {
+        "xi-api-key": ELEVEN_API_KEY,
+        "Content-Type": "application/json"
+    }
+
+    payload = {
+        "text": text,
+        "model_id": "eleven_multilingual_v2",
+        "voice_settings": {
+            "stability": 0.5,
+            "similarity_boost": 0.75
+        }
+    }
+
+    response = requests.post(url, headers=headers, json=payload)
+
+    if response.status_code != 200:
+        raise ValueError(f"음성 합성 실패: {response.status_code} {response.text}")
+
+    return BytesIO(response.content)


### PR DESCRIPTION
## 연관 이슈
close #7 

## 📌 개요
- ElevenLabs 기반 사용자 음성 등록 및 텍스트 음성 재생 기능 구현
- mp3 파일 저장 없이 스트리밍 방식으로 음성 응답 제공

## 🔧 작업 내용
- `/voice/register`: 음성 파일과 이름을 받아 클로닝 요청 후 `voice_id` 반환
- `/voice/play`: `voice_key`와 텍스트 받아 ElevenLabs로 합성 요청 후 `StreamingResponse(audio/mpeg)` 반환

## 📝 논의 사항
- 현재 Postman 또는 브라우저에서 API 호출 시 mp3가 바로 재생됨 (프론트 없이도 확인 가능)
- 추후 프론트엔드에서 음성 재생 시 어떤 방식으로 파일을 처리하고 스트리밍할지 논의 필요