### PR TITLE
[fix] 캐릭터 이미지 한명 생성 고정으로 프롬프트 수정

### DIFF
--- a/everTale/app/service/image_service.py
+++ b/everTale/app/service/image_service.py
@@ -252,14 +252,11 @@ def _select_top_traits(traits, k=3):
     return ", ".join([t.strip() for t in traits if t.strip()][:k])
 
 def build_character_prompt(name: str, age: int, gender: str, personalities: list, image_description: str) -> str:
-    gender_short = "boy" if gender.lower().startswith("m") else "girl"
-    top_traits   = _select_top_traits(personalities, k=3)
+    gender_short = "male" if gender.lower().startswith("m") else "female"
     image_desc_short = build_scene_prompt(image_description.strip())
-    core = f"{gender_short}, {top_traits}, {image_desc_short}"
-    prompt = f"{STYLE_SUFFIX_INIT}, {core}"
+    core = f"one character only, {gender_short}, {image_desc_short}"
+    prompt = f"{core}, {STYLE_SUFFIX_INIT}"
     return (prompt[:320]).rstrip(", ")
-
-
 
 def _cleanup_prompt(s: str, max_len: int = 320) -> str:
     if not s:


### PR DESCRIPTION
## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->

- 초기 캐릭터 생성의 경우 객체 하나만 생성되도록 프롬프트를 고정한다.
- SUFFIX와 core의 위치를 변경해서 core 프롬프트가 token 크기 제약으로 들어가지 않는 경우를 배제한다.

<img width="1202" height="47" alt="스크린샷 2025-10-02 오후 11 04 35" src="https://github.com/user-attachments/assets/3e2de61d-e152-49d4-8586-88d887d74e7c" />
